### PR TITLE
feat: 로컬스토리지 키값 추가

### DIFF
--- a/src/components/GlobalNavigationBar.tsx
+++ b/src/components/GlobalNavigationBar.tsx
@@ -56,7 +56,7 @@ export const GlobalNavigationBar = () => {
 
   useEffect(() => {
     if (error) {
-      console.warn('meData:', meData);
+      console.warn('meData:', meData?.me);
       // console.error('Error : User Data,', error);
       logoutBtn();
     }
@@ -70,6 +70,7 @@ export const GlobalNavigationBar = () => {
     const localViewOptions = getLocalStorageItem<IViewOption>({
       key: 'VIEW_OPTION',
       userId: meData.me.id,
+      userName: meData.me.name,
     });
 
     if (localViewOptions === null) {
@@ -104,7 +105,9 @@ export const GlobalNavigationBar = () => {
     const localClinics = getLocalStorageItem<IClinicList[]>({
       key: 'CLINIC_LISTS',
       userId: meData.me.id,
+      userName: meData.me.name,
     });
+
     if (localClinics) {
       updatedMyClinics = myClinics.map((clinic) => {
         const localClinic = localClinics.find(
@@ -136,8 +139,8 @@ export const GlobalNavigationBar = () => {
     const localSelectClinic = getLocalStorageItem<ISelectedClinic>({
       key: 'SELECTED_CLINIC',
       userId: meData.me.id,
+      userName: meData.me.name,
     });
-
     const clinic = updatedMyClinics.find((clinic) =>
       localSelectClinic
         ? clinic.id === localSelectClinic.id

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -153,17 +153,17 @@ export type SetSelectedInfoValue = SelectedInfo[SetSelectedInfoKey];
 
 // utils
 
-export interface CreateLocalStorageKey {
-  key: LocalStorageValue;
+interface UserIdAndName {
   userId: number;
+  userName: string;
 }
-export interface GetLocalStorage {
+export interface CreateLocalStorageKey extends UserIdAndName {
+  key: LocalStorageValue;
+}
+export interface GetLocalStorage extends UserIdAndName {
   key: LocalStorageKey;
-  userId: number;
 }
 
-export interface SetLocalStorage {
-  key: LocalStorageKey;
-  userId: number;
+export interface SetLocalStorage extends GetLocalStorage {
   value: any;
 }

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -81,27 +81,36 @@ export function changeValueInArray<T>(array: T[], value: T, index: number) {
 export const createLocalStorageKey = ({
   key,
   userId,
+  userName,
 }: CreateLocalStorageKey) => {
-  return key + userId;
+  return key + userId + userName;
 };
 
 export function getLocalStorageItem<T>({
   key,
   userId,
+  userName,
 }: GetLocalStorage): T | null {
   const storageKey = createLocalStorageKey({
     key: LOCAL_STORAGE_KEY[key],
     userId,
+    userName,
   });
   const item = localStorage.getItem(storageKey)!;
   if (!item) return null;
   return JSON.parse(item);
 }
 
-export const setLocalStorage = ({ key, userId, value }: SetLocalStorage) => {
+export const setLocalStorage = ({
+  key,
+  userId,
+  userName,
+  value,
+}: SetLocalStorage) => {
   const storageKey = createLocalStorageKey({
     key: LOCAL_STORAGE_KEY[key],
     userId,
+    userName,
   });
   localStorage.setItem(storageKey, JSON.stringify(value));
 };


### PR DESCRIPTION
issue : #4

## 문제파악

### 시간표
- index에서 **weekEvents**가 **false**라 무한 로딩 됨
  - weekEvents는 useEffect에서 만들어짐
    - 해당 훅은 의존성으로 **selectedInfo.clinic**를 갖는데 콘솔로그에 **nul**l임

### 대시보드
- index에서 selectedInfo.clinic이 false라 무한 로딩 됨

### selectedInfo.clinic은 어디서 값을 갖는가?

- selectedInfo.clinic은 **GlobalNavigationBar**에서 최초로 생성
- 이때 로컬스토리지에 키값이 있으면 불러와서 재사용함
- DB를 초기화 했지만 이전에 쓴 로컬스토리지 값이 남아 있었음.
- **중복되는 키의 다른 값**이 로컬스토리지에 남아 있었던 게 문제

## 해결
- 로컬스토리지의 key값에 name을 추가함

## 고려할 점
키 값에 너무 userId와 userName이 명시된다. 암호화 하던 가 다른 방법을 고려해볼 것
